### PR TITLE
[feature] implementation of user information role update

### DIFF
--- a/src/main/java/com/fhsh/daitda/user/application/command/UserRoleUpdateCommand.java
+++ b/src/main/java/com/fhsh/daitda/user/application/command/UserRoleUpdateCommand.java
@@ -1,0 +1,10 @@
+package com.fhsh.daitda.user.application.command;
+
+import com.fhsh.daitda.user.domain.enums.UserRole;
+import java.util.UUID;
+
+public record UserRoleUpdateCommand(
+        UUID userId,
+        UserRole role
+) {
+}

--- a/src/main/java/com/fhsh/daitda/user/application/command/UserUpdateCommand.java
+++ b/src/main/java/com/fhsh/daitda/user/application/command/UserUpdateCommand.java
@@ -1,0 +1,12 @@
+package com.fhsh.daitda.user.application.command;
+
+import java.util.UUID;
+
+public record UserUpdateCommand(
+        UUID userId,
+        String name,
+        String slackUserId,
+        UUID hubId,
+        UUID companyId
+) {
+}

--- a/src/main/java/com/fhsh/daitda/user/application/port/AccountPort.java
+++ b/src/main/java/com/fhsh/daitda/user/application/port/AccountPort.java
@@ -18,4 +18,6 @@ public interface AccountPort {
     AuthTokens refresh(String refreshToken);
 
     void updateAccountStatus(UUID accountId, boolean enabled);
+
+    void updateAccountRole(UUID accountId, UserRole newRole);
 }

--- a/src/main/java/com/fhsh/daitda/user/application/result/UserUpdateResult.java
+++ b/src/main/java/com/fhsh/daitda/user/application/result/UserUpdateResult.java
@@ -1,0 +1,15 @@
+package com.fhsh.daitda.user.application.result;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserUpdateResult(
+    UUID userId,
+    String name,
+    String slackUserId,
+    UUID hubId,
+    UUID companyId,
+    LocalDateTime updatedAt
+) {
+
+}

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -8,6 +8,8 @@ import com.fhsh.daitda.user.domain.enums.UserStatus;
 import com.fhsh.daitda.user.domain.exception.UserErrorCode;
 import com.fhsh.daitda.user.domain.repository.UserRepository;
 import com.fhsh.daitda.user.application.port.AccountPort;
+import com.fhsh.daitda.user.infrastructure.external.feign.CompanyClient;
+import com.fhsh.daitda.user.infrastructure.external.feign.HubClient;
 import com.fhsh.daitda.user.presentation.dto.response.UserUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,9 +23,14 @@ public class UserCommandService {
 
     private final AccountPort accountPort;
     private final UserRepository userRepository;
+    private final HubClient hubClient;
+    private final CompanyClient companyClient;
 
     @Transactional
     public void signup(SignupCommand command) {
+        // 허브 및 업체 존재 여부 검증
+        validateHubAndCompany(command.hubId(), command.companyId());
+
         // Keycloak 계정 생성 (DB 트랜잭션과 무관한 외부 통신)
         UUID keycloakId = accountPort.createAccount(
                 command.email(),
@@ -104,6 +111,9 @@ public class UserCommandService {
             throw new BusinessException(UserErrorCode.ALREADY_DELETED);
         }
 
+        // 허브 및 업체 존재 여부 검증
+        validateHubAndCompany(command.hubId(), command.companyId());
+
         user.update(command.name(), command.slackUserId(), command.hubId(), command.companyId());
         User updatedUser = userRepository.save(user);
 
@@ -128,5 +138,22 @@ public class UserCommandService {
         // 로컬 DB 권한 변경
         user.updateRole(command.role());
         userRepository.save(user);
+    }
+
+    private void validateHubAndCompany(UUID hubId, UUID companyId) {
+        if (hubId != null) {
+            try {
+                hubClient.getHubById(hubId);
+            } catch (Exception e) {
+                throw new BusinessException(UserErrorCode.INVALID_REFERENCE_ID);
+            }
+        }
+        if (companyId != null) {
+            try {
+                companyClient.getCompanyById(companyId);
+            } catch (Exception e) {
+                throw new BusinessException(UserErrorCode.INVALID_REFERENCE_ID);
+            }
+        }
     }
 }

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -3,6 +3,7 @@ import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.user.application.command.SignupCommand;
 import com.fhsh.daitda.user.application.command.UserRoleUpdateCommand;
 import com.fhsh.daitda.user.application.command.UserUpdateCommand;
+import com.fhsh.daitda.user.application.result.UserUpdateResult;
 import com.fhsh.daitda.user.domain.entity.User;
 import com.fhsh.daitda.user.domain.enums.UserStatus;
 import com.fhsh.daitda.user.domain.exception.UserErrorCode;
@@ -10,7 +11,6 @@ import com.fhsh.daitda.user.domain.repository.UserRepository;
 import com.fhsh.daitda.user.application.port.AccountPort;
 import com.fhsh.daitda.user.infrastructure.external.feign.CompanyClient;
 import com.fhsh.daitda.user.infrastructure.external.feign.HubClient;
-import com.fhsh.daitda.user.presentation.dto.response.UserUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -103,7 +103,7 @@ public class UserCommandService {
     }
 
     @Transactional
-    public UserUpdateResponse updateUser(UserUpdateCommand command) {
+    public UserUpdateResult updateUser(UserUpdateCommand command) {
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
@@ -115,9 +115,9 @@ public class UserCommandService {
         validateHubAndCompany(command.hubId(), command.companyId());
 
         user.update(command.name(), command.slackUserId(), command.hubId(), command.companyId());
-        User updatedUser = userRepository.save(user);
+        User updatedUser = userRepository.saveAndFlush(user);
 
-        return new UserUpdateResponse(
+        return new UserUpdateResult(
                 updatedUser.getUserId(),
                 updatedUser.getName(),
                 updatedUser.getSlackUserId(),

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.user.application.service.command;
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.user.application.command.SignupCommand;
+import com.fhsh.daitda.user.application.command.UserRoleUpdateCommand;
 import com.fhsh.daitda.user.application.command.UserUpdateCommand;
 import com.fhsh.daitda.user.domain.entity.User;
 import com.fhsh.daitda.user.domain.enums.UserStatus;
@@ -114,5 +115,18 @@ public class UserCommandService {
                 updatedUser.getCompanyId(),
                 updatedUser.getUpdatedAt()
         );
+    }
+
+    @Transactional
+    public void updateUserRole(UserRoleUpdateCommand command) {
+        User user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // Keycloak 권한 변경
+        accountPort.updateAccountRole(user.getUserId(), command.role());
+
+        // 로컬 DB 권한 변경
+        user.updateRole(command.role());
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -132,12 +132,12 @@ public class UserCommandService {
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // Keycloak 권한 변경
-        accountPort.updateAccountRole(user.getUserId(), command.role());
-
         // 로컬 DB 권한 변경
         user.updateRole(command.role());
-        userRepository.save(user);
+        userRepository.saveAndFlush(user);
+
+        // Keycloak 권한 변경
+        accountPort.updateAccountRole(user.getUserId(), command.role());
     }
 
     private void validateHubAndCompany(UUID hubId, UUID companyId) {

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -3,9 +3,7 @@ import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.user.application.command.SignupCommand;
 import com.fhsh.daitda.user.application.command.UserUpdateCommand;
 import com.fhsh.daitda.user.domain.entity.User;
-import com.fhsh.daitda.user.domain.enums.UserRole;
 import com.fhsh.daitda.user.domain.enums.UserStatus;
-import com.fhsh.daitda.user.domain.exception.AuthErrorCode;
 import com.fhsh.daitda.user.domain.exception.UserErrorCode;
 import com.fhsh.daitda.user.domain.repository.UserRepository;
 import com.fhsh.daitda.user.application.port.AccountPort;
@@ -101,7 +99,9 @@ public class UserCommandService {
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
-        // TODO: hubId, companyId가 실제 존재하는 값인지 확인해야함
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(UserErrorCode.ALREADY_DELETED);
+        }
 
         user.update(command.name(), command.slackUserId(), command.hubId(), command.companyId());
         User updatedUser = userRepository.save(user);

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -132,6 +132,10 @@ public class UserCommandService {
         User user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
 
+        if (user.getStatus() == UserStatus.DELETED) {
+            throw new BusinessException(UserErrorCode.ALREADY_DELETED);
+        }
+
         // 로컬 DB 권한 변경
         user.updateRole(command.role());
         userRepository.saveAndFlush(user);

--- a/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
+++ b/src/main/java/com/fhsh/daitda/user/application/service/command/UserCommandService.java
@@ -1,6 +1,7 @@
 package com.fhsh.daitda.user.application.service.command;
 import com.fhsh.daitda.exception.BusinessException;
 import com.fhsh.daitda.user.application.command.SignupCommand;
+import com.fhsh.daitda.user.application.command.UserUpdateCommand;
 import com.fhsh.daitda.user.domain.entity.User;
 import com.fhsh.daitda.user.domain.enums.UserRole;
 import com.fhsh.daitda.user.domain.enums.UserStatus;
@@ -8,6 +9,7 @@ import com.fhsh.daitda.user.domain.exception.AuthErrorCode;
 import com.fhsh.daitda.user.domain.exception.UserErrorCode;
 import com.fhsh.daitda.user.domain.repository.UserRepository;
 import com.fhsh.daitda.user.application.port.AccountPort;
+import com.fhsh.daitda.user.presentation.dto.response.UserUpdateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,5 +94,25 @@ public class UserCommandService {
 
         // Keycloak 계정 삭제
         accountPort.deleteAccount(targetUserId);
+    }
+
+    @Transactional
+    public UserUpdateResponse updateUser(UserUpdateCommand command) {
+        User user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+
+        // TODO: hubId, companyId가 실제 존재하는 값인지 확인해야함
+
+        user.update(command.name(), command.slackUserId(), command.hubId(), command.companyId());
+        User updatedUser = userRepository.save(user);
+
+        return new UserUpdateResponse(
+                updatedUser.getUserId(),
+                updatedUser.getName(),
+                updatedUser.getSlackUserId(),
+                updatedUser.getHubId(),
+                updatedUser.getCompanyId(),
+                updatedUser.getUpdatedAt()
+        );
     }
 }

--- a/src/main/java/com/fhsh/daitda/user/domain/entity/User.java
+++ b/src/main/java/com/fhsh/daitda/user/domain/entity/User.java
@@ -118,6 +118,13 @@ public class User extends BaseUserEntity {
         }
     }
 
+    public void updateRole(UserRole role) {
+        if (role == null) {
+            throw new BusinessException(UserErrorCode.INVALID_USER_INPUT, "권한은 필수 입력 값입니다.");
+        }
+        this.role = role;
+    }
+
     private void validateEmail(String email) {
         if (!StringUtils.hasText(email) || !email.contains("@")) {
             throw new BusinessException(UserErrorCode.INVALID_EMAIL_FORMAT);

--- a/src/main/java/com/fhsh/daitda/user/domain/entity/User.java
+++ b/src/main/java/com/fhsh/daitda/user/domain/entity/User.java
@@ -102,6 +102,22 @@ public class User extends BaseUserEntity {
         this.approve();
     }
 
+    public void update(String name, String slackUserId, UUID hubId, UUID companyId) {
+        if (name != null) {
+            validateName(name);
+            this.name = name;
+        }
+        if (slackUserId != null) {
+            this.slackUserId = slackUserId;
+        }
+        if (hubId != null) {
+            this.hubId = hubId;
+        }
+        if (companyId != null) {
+            this.companyId = companyId;
+        }
+    }
+
     private void validateEmail(String email) {
         if (!StringUtils.hasText(email) || !email.contains("@")) {
             throw new BusinessException(UserErrorCode.INVALID_EMAIL_FORMAT);

--- a/src/main/java/com/fhsh/daitda/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/fhsh/daitda/user/domain/exception/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_USER_INPUT(HttpStatus.BAD_REQUEST, "잘못된 사용자 입력 값입니다."),
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "올바르지 않은 이메일 형식입니다."),
     AUDITOR_INFO_TOO_LONG(HttpStatus.BAD_REQUEST, "수정자 정보가 허용된 길이를 초과했습니다."),
+    INVALID_REFERENCE_ID(HttpStatus.BAD_REQUEST, "참조된 리소스가 유효하지 않습니다."),
 
     // 401 Unauthorized / 403 Forbidden
     USER_NOT_APPROVED(HttpStatus.FORBIDDEN, "승인되지 않은 사용자입니다."),

--- a/src/main/java/com/fhsh/daitda/user/infrastructure/external/feign/CompanyClient.java
+++ b/src/main/java/com/fhsh/daitda/user/infrastructure/external/feign/CompanyClient.java
@@ -1,0 +1,14 @@
+package com.fhsh.daitda.user.infrastructure.external.feign;
+
+import com.fhsh.daitda.response.CommonResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "company-service")
+public interface CompanyClient {
+    @GetMapping("/internal/v1/companies/{companyId}")
+    CommonResponse<Object> getCompanyById(@PathVariable("companyId") UUID companyId);
+}

--- a/src/main/java/com/fhsh/daitda/user/infrastructure/external/feign/HubClient.java
+++ b/src/main/java/com/fhsh/daitda/user/infrastructure/external/feign/HubClient.java
@@ -1,0 +1,14 @@
+package com.fhsh.daitda.user.infrastructure.external.feign;
+
+import com.fhsh.daitda.response.CommonResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.UUID;
+
+@FeignClient(name = "hub-service")
+public interface HubClient {
+    @GetMapping("/internal/v1/hubs/{hubId}")
+    CommonResponse<Object> getHubById(@PathVariable("hubId") UUID hubId);
+}

--- a/src/main/java/com/fhsh/daitda/user/infrastructure/external/keycloak/KeycloakAccountAdapter.java
+++ b/src/main/java/com/fhsh/daitda/user/infrastructure/external/keycloak/KeycloakAccountAdapter.java
@@ -172,17 +172,20 @@ public class KeycloakAccountAdapter implements AccountPort {
                     .map(Enum::name)
                     .collect(Collectors.toSet());
 
+            // 변경하려는 대상 권한을 이미 가지고 있는지 확인
+            boolean alreadyHasTargetRole = currentRoles.stream()
+                    .anyMatch(role -> newRole.name().equals(role.getName()));
+            if (!alreadyHasTargetRole) {
+                assignRoleToUser(accountId.toString(), newRole.name());
+            }
+
             List<RoleRepresentation> rolesToRemove = currentRoles.stream()
                     .filter(role -> appRoleNames.contains(role.getName()))
+                    .filter(role -> !newRole.name().equals(role.getName()))
                     .toList();
-
-            // 기존 애플리케이션 권한 삭제
             if (!rolesToRemove.isEmpty()) {
                 userResource.roles().realmLevel().remove(rolesToRemove);
             }
-
-            // 새로운 권한 부여
-            assignRoleToUser(accountId.toString(), newRole.name());
 
         } catch (Exception e) {
             throw new BusinessException(AuthErrorCode.AUTH_SERVER_ERROR);

--- a/src/main/java/com/fhsh/daitda/user/infrastructure/external/keycloak/KeycloakAccountAdapter.java
+++ b/src/main/java/com/fhsh/daitda/user/infrastructure/external/keycloak/KeycloakAccountAdapter.java
@@ -20,10 +20,8 @@ import org.keycloak.representations.idm.UserRepresentation;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -156,6 +154,36 @@ public class KeycloakAccountAdapter implements AccountPort {
             UserRepresentation user = userResource.toRepresentation();
             user.setEnabled(enabled);
             userResource.update(user);
+        } catch (Exception e) {
+            throw new BusinessException(AuthErrorCode.AUTH_SERVER_ERROR);
+        }
+    }
+
+    @Override
+    public void updateAccountRole(UUID accountId, UserRole newRole) {
+        try {
+            UserResource userResource = keycloak.realm(realm).users().get(accountId.toString());
+
+            // 현재 사용자에게 부여된 렐름 레벨 권한 목록 조회
+            List<RoleRepresentation> currentRoles = userResource.roles().realmLevel().listAll();
+
+            // 우리 애플리케이션에서 사용하는 권한(UserRole enum에 정의된 것들) 필터링
+            Set<String> appRoleNames = Arrays.stream(UserRole.values())
+                    .map(Enum::name)
+                    .collect(Collectors.toSet());
+
+            List<RoleRepresentation> rolesToRemove = currentRoles.stream()
+                    .filter(role -> appRoleNames.contains(role.getName()))
+                    .toList();
+
+            // 기존 애플리케이션 권한 삭제
+            if (!rolesToRemove.isEmpty()) {
+                userResource.roles().realmLevel().remove(rolesToRemove);
+            }
+
+            // 새로운 권한 부여
+            assignRoleToUser(accountId.toString(), newRole.name());
+
         } catch (Exception e) {
             throw new BusinessException(AuthErrorCode.AUTH_SERVER_ERROR);
         }

--- a/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
@@ -63,7 +63,7 @@ public class UserExternalController {
     @PatchMapping("/{userId}")
     public CommonResponse<UserUpdateResponse> updateUser(
             @PathVariable("userId") UUID userId,
-            @RequestBody UserUpdateRequest request
+            @Valid @RequestBody UserUpdateRequest request
     ) {
         UserUpdateResponse response = userCommandService.updateUser(new UserUpdateCommand(
                 userId,

--- a/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
@@ -37,7 +37,7 @@ public class UserExternalController {
         return CommonResponse.success();
     }
 
-    @HasRole("ADMIN")
+    @HasRole({"ADMIN", "HUB_ADMIN"})
     @PostMapping("/{userId}/registration")
     public CommonResponse<Void> registration(
             @PathVariable("userId") UUID userId,

--- a/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
@@ -3,9 +3,12 @@ package com.fhsh.daitda.user.presentation.controller.external;
 import com.fhsh.daitda.common.annotation.HasRole;
 import com.fhsh.daitda.response.CommonResponse;
 import com.fhsh.daitda.user.application.command.SignupCommand;
+import com.fhsh.daitda.user.application.command.UserUpdateCommand;
 import com.fhsh.daitda.user.application.service.command.UserCommandService;
 import com.fhsh.daitda.user.presentation.dto.request.UserRegistrationRequest;
 import com.fhsh.daitda.user.presentation.dto.request.UserSignupRequest;
+import com.fhsh.daitda.user.presentation.dto.request.UserUpdateRequest;
+import com.fhsh.daitda.user.presentation.dto.response.UserUpdateResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -52,5 +55,21 @@ public class UserExternalController {
     ) {
         userCommandService.deleteUser(userId, requesterId);
         return CommonResponse.success();
+    }
+
+    @HasRole("ADMIN")
+    @PatchMapping("/{userId}")
+    public CommonResponse<UserUpdateResponse> updateUser(
+            @PathVariable("userId") UUID userId,
+            @RequestBody UserUpdateRequest request
+    ) {
+        UserUpdateResponse response = userCommandService.updateUser(new UserUpdateCommand(
+                userId,
+                request.name(),
+                request.slackUserId(),
+                request.hubId(),
+                request.companyId()
+        ));
+        return CommonResponse.success("사용자 정보 수정 성공", response);
     }
 }

--- a/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
@@ -3,9 +3,11 @@ package com.fhsh.daitda.user.presentation.controller.external;
 import com.fhsh.daitda.common.annotation.HasRole;
 import com.fhsh.daitda.response.CommonResponse;
 import com.fhsh.daitda.user.application.command.SignupCommand;
+import com.fhsh.daitda.user.application.command.UserRoleUpdateCommand;
 import com.fhsh.daitda.user.application.command.UserUpdateCommand;
 import com.fhsh.daitda.user.application.service.command.UserCommandService;
 import com.fhsh.daitda.user.presentation.dto.request.UserRegistrationRequest;
+import com.fhsh.daitda.user.presentation.dto.request.UserRoleUpdateRequest;
 import com.fhsh.daitda.user.presentation.dto.request.UserSignupRequest;
 import com.fhsh.daitda.user.presentation.dto.request.UserUpdateRequest;
 import com.fhsh.daitda.user.presentation.dto.response.UserUpdateResponse;
@@ -71,5 +73,15 @@ public class UserExternalController {
                 request.companyId()
         ));
         return CommonResponse.success("사용자 정보 수정 성공", response);
+    }
+
+    @HasRole("ADMIN")
+    @PatchMapping("/{userId}/role")
+    public CommonResponse<Void> updateUserRole(
+            @PathVariable("userId") UUID userId,
+            @Valid @RequestBody UserRoleUpdateRequest request
+    ) {
+        userCommandService.updateUserRole(new UserRoleUpdateCommand(userId, request.role()));
+        return CommonResponse.success("사용자 권한 변경 성공", null);
     }
 }

--- a/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/controller/external/UserExternalController.java
@@ -5,6 +5,7 @@ import com.fhsh.daitda.response.CommonResponse;
 import com.fhsh.daitda.user.application.command.SignupCommand;
 import com.fhsh.daitda.user.application.command.UserRoleUpdateCommand;
 import com.fhsh.daitda.user.application.command.UserUpdateCommand;
+import com.fhsh.daitda.user.application.result.UserUpdateResult;
 import com.fhsh.daitda.user.application.service.command.UserCommandService;
 import com.fhsh.daitda.user.presentation.dto.request.UserRegistrationRequest;
 import com.fhsh.daitda.user.presentation.dto.request.UserRoleUpdateRequest;
@@ -65,14 +66,14 @@ public class UserExternalController {
             @PathVariable("userId") UUID userId,
             @Valid @RequestBody UserUpdateRequest request
     ) {
-        UserUpdateResponse response = userCommandService.updateUser(new UserUpdateCommand(
+        UserUpdateResult result = userCommandService.updateUser(new UserUpdateCommand(
                 userId,
                 request.name(),
                 request.slackUserId(),
                 request.hubId(),
                 request.companyId()
         ));
-        return CommonResponse.success("사용자 정보 수정 성공", response);
+        return CommonResponse.success("사용자 정보 수정 성공", UserUpdateResponse.from(result));
     }
 
     @HasRole("ADMIN")

--- a/src/main/java/com/fhsh/daitda/user/presentation/dto/request/UserRoleUpdateRequest.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/dto/request/UserRoleUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.fhsh.daitda.user.presentation.dto.request;
+
+import com.fhsh.daitda.user.domain.enums.UserRole;
+import jakarta.validation.constraints.NotNull;
+
+public record UserRoleUpdateRequest(
+        @NotNull UserRole role
+) {
+}

--- a/src/main/java/com/fhsh/daitda/user/presentation/dto/request/UserUpdateRequest.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/dto/request/UserUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.fhsh.daitda.user.presentation.dto.request;
+
+import java.util.UUID;
+
+public record UserUpdateRequest(
+        String name,
+        String slackUserId,
+        UUID hubId,
+        UUID companyId
+) {
+}

--- a/src/main/java/com/fhsh/daitda/user/presentation/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/dto/response/UserUpdateResponse.java
@@ -1,0 +1,14 @@
+package com.fhsh.daitda.user.presentation.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record UserUpdateResponse(
+        UUID userId,
+        String name,
+        String slackUserId,
+        UUID hubId,
+        UUID companyId,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/fhsh/daitda/user/presentation/dto/response/UserUpdateResponse.java
+++ b/src/main/java/com/fhsh/daitda/user/presentation/dto/response/UserUpdateResponse.java
@@ -1,5 +1,8 @@
 package com.fhsh.daitda.user.presentation.dto.response;
 
+import com.fhsh.daitda.user.application.result.UserQueryResult;
+import com.fhsh.daitda.user.application.result.UserUpdateResult;
+
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -11,4 +14,14 @@ public record UserUpdateResponse(
         UUID companyId,
         LocalDateTime updatedAt
 ) {
+    public static UserUpdateResponse from(UserUpdateResult result) {
+        return new UserUpdateResponse(
+                result.userId(),
+                result.name(),
+                result.slackUserId(),
+                result.hubId(),
+                result.companyId(),
+                result.updatedAt()
+        );
+    }
 }


### PR DESCRIPTION
## 🌱 설명

- 사용자 권한 변경 api
- 사용자 정보 수정 api
- 회원 가입 및 정보 수정시 hubId와 companyId 검증 (feignclient 통신)

## 📌 관련 이슈

- close #20 

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 정보 수정 기능 추가 — 이름, Slack ID, 허브, 회사 정보 변경 및 외부 참조 유효성 검사 포함
  * 사용자 역할 수정 기능 추가 — 로컬 역할 변경 시 인증 서버의 계정 역할도 동기화
  * 외부 API 연동 클라이언트 추가로 허브/회사 조회 지원
  * 사용자 등록 권한에 HUB_ADMIN 권한 추가 적용
* **검증**
  * 역할 변경 요청에서 역할 필수 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->